### PR TITLE
Refine Google Material icon integration

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -25,3 +25,31 @@ body {
 
 @import "_material_overrides";
 @import 'custom_material';
+
+.material-symbols-outlined {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'OPSZ' 24;
+  font-size: 1.25rem;
+  line-height: 1;
+  vertical-align: middle;
+}
+
+.navbar-brand .material-symbols-outlined {
+  font-size: 1.6rem;
+}
+
+.nav-link .material-symbols-outlined {
+  font-size: 1.3rem;
+}
+
+.btn .material-symbols-outlined {
+  font-size: 1.1rem;
+}
+
+.card-header .material-symbols-outlined {
+  font-size: 1.3rem;
+}
+
+.list-unstyled .material-symbols-outlined,
+.list-group-item .material-symbols-outlined {
+  font-size: 1.25rem;
+}

--- a/app/views/health_records/index.html.erb
+++ b/app/views/health_records/index.html.erb
@@ -1,6 +1,12 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h2 class="h4 mb-0">健康ログ一覧</h2>
-  <%= link_to "新規登録", new_health_record_path, class: "btn btn-primary" %>
+  <h2 class="h4 mb-0 d-flex align-items-center gap-2">
+    <span class="material-symbols-outlined text-primary" aria-hidden="true">monitoring</span>
+    <span>健康ログ一覧</span>
+  </h2>
+  <%= link_to new_health_record_path, class: "btn btn-primary d-inline-flex align-items-center gap-2" do %>
+    <span class="material-symbols-outlined" aria-hidden="true">post_add</span>
+    <span>新規登録</span>
+  <% end %>
 </div>
 
 <% if notice.present? %>
@@ -32,9 +38,18 @@
             <td><%= record.fatigue_level || "-" %></td>
             <td><%= record.activity_logs.count %>件</td>
             <td class="text-end">
-              <%= link_to "詳細", health_record_path(record), class: "btn btn-sm btn-outline-primary me-1" %>
-              <%= link_to "編集", edit_health_record_path(record), class: "btn btn-sm btn-outline-secondary me-1" %>
-              <%= link_to "削除", health_record_path(record), class: "btn btn-sm btn-outline-danger", data: { turbo_method: :delete, turbo_confirm: "削除してよろしいですか？" } %>
+              <%= link_to health_record_path(record), class: "btn btn-sm btn-outline-primary me-1 d-inline-flex align-items-center gap-1" do %>
+                <span class="material-symbols-outlined" aria-hidden="true">visibility</span>
+                <span>詳細</span>
+              <% end %>
+              <%= link_to edit_health_record_path(record), class: "btn btn-sm btn-outline-secondary me-1 d-inline-flex align-items-center gap-1" do %>
+                <span class="material-symbols-outlined" aria-hidden="true">edit</span>
+                <span>編集</span>
+              <% end %>
+              <%= link_to health_record_path(record), class: "btn btn-sm btn-outline-danger d-inline-flex align-items-center gap-1", data: { turbo_method: :delete, turbo_confirm: "削除してよろしいですか？" } do %>
+                <span class="material-symbols-outlined" aria-hidden="true">delete</span>
+                <span>削除</span>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/health_records/show.html.erb
+++ b/app/views/health_records/show.html.erb
@@ -1,8 +1,17 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h2 class="h4 mb-0"><%= @health_record.recorded_at ? l(@health_record.recorded_at, format: "%Y-%m-%d %H:%M") : "日時未設定" %> の記録</h2>
+  <h2 class="h4 mb-0 d-flex align-items-center gap-2">
+    <span class="material-symbols-outlined text-primary" aria-hidden="true">calendar_month</span>
+    <span><%= @health_record.recorded_at ? l(@health_record.recorded_at, format: "%Y-%m-%d %H:%M") : "日時未設定" %> の記録</span>
+  </h2>
   <div class="d-flex gap-2">
-    <%= link_to "編集", edit_health_record_path(@health_record), class: "btn btn-outline-secondary btn-sm" %>
-    <%= link_to "一覧に戻る", health_records_path, class: "btn btn-outline-primary btn-sm" %>
+    <%= link_to edit_health_record_path(@health_record), class: "btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2" do %>
+      <span class="material-symbols-outlined" aria-hidden="true">edit</span>
+      <span>編集</span>
+    <% end %>
+    <%= link_to health_records_path, class: "btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2" do %>
+      <span class="material-symbols-outlined" aria-hidden="true">arrow_back</span>
+      <span>一覧に戻る</span>
+    <% end %>
   </div>
 </div>
 
@@ -10,7 +19,10 @@
   <div class="col-lg-6">
     <div class="card shadow-sm h-100">
       <div class="card-header">
-        <h3 class="h6 mb-0">状態</h3>
+        <h3 class="h6 mb-0 d-flex align-items-center gap-2">
+          <span class="material-symbols-outlined text-primary" aria-hidden="true">monitor_heart</span>
+          <span>状態</span>
+        </h3>
       </div>
       <div class="card-body">
         <dl class="row mb-0">
@@ -29,7 +41,10 @@
   <div class="col-lg-6">
     <div class="card shadow-sm h-100">
       <div class="card-header">
-        <h3 class="h6 mb-0">健康カスタム項目</h3>
+        <h3 class="h6 mb-0 d-flex align-items-center gap-2">
+          <span class="material-symbols-outlined text-primary" aria-hidden="true">tune</span>
+          <span>健康カスタム項目</span>
+        </h3>
       </div>
       <div class="card-body">
         <% health_fields = @health_custom_fields.select { |field| custom_field_value_present?(field, @health_record.custom_fields) } %>
@@ -52,7 +67,10 @@
 
 <div class="card shadow-sm mt-3">
   <div class="card-header d-flex justify-content-between align-items-center">
-    <h3 class="h6 mb-0">運動記録</h3>
+    <h3 class="h6 mb-0 d-flex align-items-center gap-2">
+      <span class="material-symbols-outlined text-primary" aria-hidden="true">fitness_center</span>
+      <span>運動記録</span>
+    </h3>
   </div>
   <div class="card-body">
     <% if @health_record.activity_logs.any? %>
@@ -61,12 +79,18 @@
           <div class="list-group-item">
             <div class="d-flex justify-content-between">
               <div>
-                <strong><%= activity.activity_type.presence || "未入力" %></strong>
-                <div class="text-muted small">
+                <div class="d-flex align-items-center gap-2">
+                  <span class="material-symbols-outlined text-primary" aria-hidden="true">directions_run</span>
+                  <strong><%= activity.activity_type.presence || "未入力" %></strong>
+                </div>
+                <div class="text-muted small ms-4">
                   強度: <%= activity.intensity || "-" %>
                 </div>
               </div>
-              <span><%= activity.duration_minutes ? "#{activity.duration_minutes} 分" : "-" %></span>
+              <span class="d-inline-flex align-items-center gap-1 text-muted">
+                <span class="material-symbols-outlined" aria-hidden="true">schedule</span>
+                <span><%= activity.duration_minutes ? "#{activity.duration_minutes} 分" : "-" %></span>
+              </span>
             </div>
             <% activity_fields = @activity_custom_fields.select { |field| custom_field_value_present?(field, activity.custom_fields) } %>
             <% if activity_fields.any? %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,10 +1,16 @@
 <div class="row g-3 align-items-center mb-4">
   <div class="col-md-8">
-    <h1 class="h3 mb-2">ダッシュボード</h1>
+    <h1 class="h3 mb-2 d-flex align-items-center gap-2">
+      <span class="material-symbols-outlined text-primary" aria-hidden="true">space_dashboard</span>
+      <span>ダッシュボード</span>
+    </h1>
     <p class="text-muted mb-0">最新の健康状態と週次サマリーを確認できます。</p>
   </div>
   <div class="col-md-4 text-md-end">
-    <%= link_to "健康ログを登録", new_health_record_path, class: "btn btn-primary" %>
+    <%= link_to new_health_record_path, class: "btn btn-primary d-inline-flex align-items-center gap-2" do %>
+      <span class="material-symbols-outlined" aria-hidden="true">add_circle</span>
+      <span>健康ログを登録</span>
+    <% end %>
   </div>
 </div>
 
@@ -12,21 +18,39 @@
   <div class="col-lg-4">
     <div class="card shadow-sm h-100">
       <div class="card-header">
-        <h2 class="h6 mb-0">プロフィール概要</h2>
+        <h2 class="h6 mb-0 d-flex align-items-center gap-2">
+          <span class="material-symbols-outlined text-primary" aria-hidden="true">badge</span>
+          <span>プロフィール概要</span>
+        </h2>
       </div>
       <div class="card-body">
         <% if @profile.present? && @profile.persisted? %>
           <ul class="list-unstyled mb-0">
-            <li class="mb-2"><span class="text-muted">年齢:</span> <%= @profile.age || "-" %></li>
-            <li class="mb-2"><span class="text-muted">身長:</span> <%= @profile.height_cm ? "#{@profile.height_cm} cm" : "-" %></li>
-            <li><span class="text-muted">体重:</span> <%= @profile.weight_kg ? "#{@profile.weight_kg} kg" : "-" %></li>
+            <li class="mb-2 d-flex align-items-center gap-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">cake</span>
+              <span><span class="text-muted">年齢:</span> <%= @profile.age || "-" %></span>
+            </li>
+            <li class="mb-2 d-flex align-items-center gap-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">straighten</span>
+              <span><span class="text-muted">身長:</span> <%= @profile.height_cm ? "#{@profile.height_cm} cm" : "-" %></span>
+            </li>
+            <li class="d-flex align-items-center gap-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">monitor_weight</span>
+              <span><span class="text-muted">体重:</span> <%= @profile.weight_kg ? "#{@profile.weight_kg} kg" : "-" %></span>
+            </li>
           </ul>
           <div class="mt-3">
-            <%= link_to "基本情報を見る", profile_path, class: "btn btn-outline-primary btn-sm" %>
+            <%= link_to profile_path, class: "btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2" do %>
+              <span class="material-symbols-outlined" aria-hidden="true">open_in_new</span>
+              <span>基本情報を見る</span>
+            <% end %>
           </div>
         <% else %>
           <p class="text-muted">基本情報が未登録です。</p>
-          <%= link_to "登録する", edit_profile_path, class: "btn btn-outline-primary btn-sm" %>
+          <%= link_to edit_profile_path, class: "btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2" do %>
+            <span class="material-symbols-outlined" aria-hidden="true">edit</span>
+            <span>登録する</span>
+          <% end %>
         <% end %>
       </div>
     </div>
@@ -35,17 +59,32 @@
   <div class="col-lg-4">
     <div class="card shadow-sm h-100">
       <div class="card-header">
-        <h2 class="h6 mb-0">最新の健康ログ</h2>
+        <h2 class="h6 mb-0 d-flex align-items-center gap-2">
+          <span class="material-symbols-outlined text-primary" aria-hidden="true">monitor_heart</span>
+          <span>最新の健康ログ</span>
+        </h2>
       </div>
       <div class="card-body">
         <% if @latest_record.present? %>
           <p class="text-muted mb-1"><%= @latest_record.recorded_at ? l(@latest_record.recorded_at, format: "%Y-%m-%d %H:%M") : "日時未設定" %> の記録</p>
           <ul class="list-unstyled mb-3">
-            <li>気分: <strong><%= @latest_record.mood || "-" %></strong></li>
-            <li>ストレス: <strong><%= @latest_record.stress_level || "-" %></strong></li>
-            <li>疲労感: <strong><%= @latest_record.fatigue_level || "-" %></strong></li>
+            <li class="d-flex align-items-center gap-2 mb-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">sentiment_satisfied</span>
+              <span>気分: <strong><%= @latest_record.mood || "-" %></strong></span>
+            </li>
+            <li class="d-flex align-items-center gap-2 mb-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">self_improvement</span>
+              <span>ストレス: <strong><%= @latest_record.stress_level || "-" %></strong></span>
+            </li>
+            <li class="d-flex align-items-center gap-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">bedtime</span>
+              <span>疲労感: <strong><%= @latest_record.fatigue_level || "-" %></strong></span>
+            </li>
           </ul>
-          <%= link_to "詳細を見る", health_record_path(@latest_record), class: "btn btn-outline-primary btn-sm" %>
+          <%= link_to health_record_path(@latest_record), class: "btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2" do %>
+            <span class="material-symbols-outlined" aria-hidden="true">visibility</span>
+            <span>詳細を見る</span>
+          <% end %>
         <% else %>
           <p class="text-muted mb-0">健康ログが登録されていません。</p>
         <% end %>
@@ -56,19 +95,37 @@
   <div class="col-lg-4">
     <div class="card shadow-sm h-100">
       <div class="card-header">
-        <h2 class="h6 mb-0">週次サマリー</h2>
+        <h2 class="h6 mb-0 d-flex align-items-center gap-2">
+          <span class="material-symbols-outlined text-primary" aria-hidden="true">query_stats</span>
+          <span>週次サマリー</span>
+        </h2>
       </div>
       <div class="card-body">
         <% if @weekly_summary.present? && @weekly_summary.buckets.any? %>
           <% latest_bucket = @weekly_summary.buckets.last %>
           <p class="text-muted mb-2"><%= latest_bucket.label %></p>
           <ul class="list-unstyled mb-3">
-            <li>平均気分: <strong><%= latest_bucket.averages[:mood]&.round(1) || "-" %></strong></li>
-            <li>平均ストレス: <strong><%= latest_bucket.averages[:stress_level]&.round(1) || "-" %></strong></li>
-            <li>平均疲労: <strong><%= latest_bucket.averages[:fatigue_level]&.round(1) || "-" %></strong></li>
-            <li>運動時間合計: <strong><%= latest_bucket.total_activity_duration %> 分</strong></li>
+            <li class="d-flex align-items-center gap-2 mb-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">mood</span>
+              <span>平均気分: <strong><%= latest_bucket.averages[:mood]&.round(1) || "-" %></strong></span>
+            </li>
+            <li class="d-flex align-items-center gap-2 mb-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">spa</span>
+              <span>平均ストレス: <strong><%= latest_bucket.averages[:stress_level]&.round(1) || "-" %></strong></span>
+            </li>
+            <li class="d-flex align-items-center gap-2 mb-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">bedtime</span>
+              <span>平均疲労: <strong><%= latest_bucket.averages[:fatigue_level]&.round(1) || "-" %></strong></span>
+            </li>
+            <li class="d-flex align-items-center gap-2">
+              <span class="material-symbols-outlined text-primary" aria-hidden="true">directions_run</span>
+              <span>運動時間合計: <strong><%= latest_bucket.total_activity_duration %> 分</strong></span>
+            </li>
           </ul>
-          <%= link_to "サマリー詳細", summaries_path(period: "weekly"), class: "btn btn-outline-primary btn-sm" %>
+          <%= link_to summaries_path(period: "weekly"), class: "btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2" do %>
+            <span class="material-symbols-outlined" aria-hidden="true">analytics</span>
+            <span>サマリー詳細</span>
+          <% end %>
         <% else %>
           <p class="text-muted mb-0">サマリーを表示できるデータがありません。</p>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24..48,400..700,0..1,-50..200&display=swap" />
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
@@ -16,7 +16,10 @@
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
       <div class="container">
-        <a class="navbar-brand fw-bold" href="<%= user_signed_in? ? root_path : root_path %>">My PHR</a>
+        <a class="navbar-brand fw-bold d-flex align-items-center gap-2" href="<%= user_signed_in? ? root_path : root_path %>">
+          <span class="material-symbols-outlined" aria-hidden="true">health_and_safety</span>
+          <span>My PHR</span>
+        </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
@@ -24,30 +27,54 @@
           <% if user_signed_in? %>
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
               <li class="nav-item">
-                <%= link_to "ダッシュボード", root_path, class: "nav-link#{current_page?(root_path) ? ' active' : ''}" %>
+                <%= link_to root_path, class: "nav-link d-flex align-items-center gap-2#{current_page?(root_path) ? ' active' : ''}" do %>
+                  <span class="material-symbols-outlined" aria-hidden="true">dashboard</span>
+                  <span>ダッシュボード</span>
+                <% end %>
               </li>
               <li class="nav-item">
-                <%= link_to "基本情報", profile_path, class: "nav-link#{controller_name == 'profiles' ? ' active' : ''}" %>
+                <%= link_to profile_path, class: "nav-link d-flex align-items-center gap-2#{controller_name == 'profiles' ? ' active' : ''}" do %>
+                  <span class="material-symbols-outlined" aria-hidden="true">account_circle</span>
+                  <span>基本情報</span>
+                <% end %>
               </li>
               <li class="nav-item">
-                <%= link_to "健康ログ", health_records_path, class: "nav-link#{controller_name == 'health_records' ? ' active' : ''}" %>
+                <%= link_to health_records_path, class: "nav-link d-flex align-items-center gap-2#{controller_name == 'health_records' ? ' active' : ''}" do %>
+                  <span class="material-symbols-outlined" aria-hidden="true">note_alt</span>
+                  <span>健康ログ</span>
+                <% end %>
               </li>
               <li class="nav-item">
-                <%= link_to "サマリー", summaries_path, class: "nav-link#{controller_name == 'summaries' ? ' active' : ''}" %>
+                <%= link_to summaries_path, class: "nav-link d-flex align-items-center gap-2#{controller_name == 'summaries' ? ' active' : ''}" do %>
+                  <span class="material-symbols-outlined" aria-hidden="true">insights</span>
+                  <span>サマリー</span>
+                <% end %>
               </li>
               <li class="nav-item">
-                <%= link_to "カスタム項目設定", custom_fields_path, class: "nav-link#{controller_name == 'custom_fields' ? ' active' : ''}" %>
+                <%= link_to custom_fields_path, class: "nav-link d-flex align-items-center gap-2#{controller_name == 'custom_fields' ? ' active' : ''}" do %>
+                  <span class="material-symbols-outlined" aria-hidden="true">tune</span>
+                  <span>カスタム項目設定</span>
+                <% end %>
               </li>
             </ul>
             <div class="d-flex align-items-center gap-2">
               <span class="text-white-50 small"><%= current_user.email %></span>
-              <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-sm btn-outline-light" %>
+              <%= button_to destroy_user_session_path, method: :delete, class: "btn btn-sm btn-outline-light d-inline-flex align-items-center gap-2" do %>
+                <span class="material-symbols-outlined" aria-hidden="true">logout</span>
+                <span>ログアウト</span>
+              <% end %>
             </div>
           <% else %>
             <div class="ms-auto d-flex gap-2">
-              <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline-light btn-sm" %>
+              <%= link_to new_user_session_path, class: "btn btn-outline-light btn-sm d-inline-flex align-items-center gap-2" do %>
+                <span class="material-symbols-outlined" aria-hidden="true">login</span>
+                <span>ログイン</span>
+              <% end %>
               <% if devise_mapping.registerable? %>
-                <%= link_to "新規登録", new_user_registration_path, class: "btn btn-light btn-sm" %>
+                <%= link_to new_user_registration_path, class: "btn btn-light btn-sm d-inline-flex align-items-center gap-2" do %>
+                  <span class="material-symbols-outlined" aria-hidden="true">person_add</span>
+                  <span>新規登録</span>
+                <% end %>
               <% end %>
             </div>
           <% end %>


### PR DESCRIPTION
## Summary
- ensure the Material Symbols icons are loaded from Google's CDN with explicit variant parameters so Google icons render reliably

## Testing
- bin/rails test *(fails: missing gems in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f990402e408329882aaa041670d921